### PR TITLE
Publish release artifact on master merge

### DIFF
--- a/.maven.settings.xml
+++ b/.maven.settings.xml
@@ -1,0 +1,53 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <profiles>
+        <profile>
+            <id>artifactory</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <repositories>
+                <repository>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <id>central</id>
+                    <name>libs-release</name>
+                    <url>http://artifactory-sdc.onsdigital.uk/artifactory/libs-release-local</url>
+                </repository>
+                <repository>
+                    <id>snapshots</id>
+                    <url>http://artifactory-sdc.onsdigital.uk/artifactory/libs-snapshot-local/</url>
+                </repository>
+                <repository>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <id>maven-central</id>
+                    <name>Central Repository</name>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>artifactory</activeProfile>
+    </activeProfiles>
+
+    <servers>
+        <server>
+            <username>travis</username>
+            <password>${env.ARTIFACTORY_PASSWORD}</password>
+            <id>central</id>
+        </server>
+        <server>
+            <username>travis</username>
+            <password>${env.ARTIFACTORY_PASSWORD}</password>
+            <id>snapshots</id>
+        </server>
+    </servers>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     git config --global user.email "travis@travis-ci.org";
     git config --global user.name "Travis CI";
-    mvn -B -Dusername=$GITHUB_API_KEY release:prepare;
+    mvn -s .maven.settings.xml -B -Dusername=$GITHUB_API_KEY release:prepare;
     mvn -s .maven.settings.xml -B release:perform;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     git checkout $TRAVIS_BRANCH;
     fi
-  - curl ifconfig.co|xargs echo "Travis IP address is ";
 
 script:
   - "mvn cobertura:cobertura"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: java
+jdk: openjdk8
+
+before_install:
+  # Checkout master branch not commit on master builds
+  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    git checkout $TRAVIS_BRANCH;
+    fi
+  - curl ifconfig.co|xargs echo "Travis IP address is ";
+
+script:
+  - "mvn cobertura:cobertura"
+  - mvn test -B
+  # Only release on master builds
+  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    git config --global user.email "travis@travis-ci.org";
+    git config --global user.name "Travis CI";
+    mvn -B -Dusername=$GITHUB_API_KEY release:prepare;
+    mvn -s .maven.settings.xml -B release:perform;
+    fi
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
+notifications:
+  slack:
+    rooms:
+      secure: rt2ut/ACihO/TIxlOawQ8//ZBzEaW7ADRQ5KEFuBQAwhZSAi+QnauH52Cb7K5AxjmTsYN9r6yyu7sW82HBrRss5qRxCJW76i/KclILvtaHmfy1YfrPLhiJUQFLLQh0INqhJPi8uEfbxBrWxqf+7tEkhMU9/Sj9z2OTNRWEk7jL6ulbIzKL5SCxf7leNVjVG8a3JX0WO70R2XU/5oMFOjRWGzgSpz9BcN40jzCDsXwM2l1gPrwPcCpxF8gjA0ZgyS/5jJd0gVHX6Gj4dzkusiPyP1VVTk8IHop1aMMR3iqpqmr0qp8UB7jrDLe8t/Y2NA/0g2o59K64OBeaJP/gP7VH/u1lWburCKJ/rBEuPfLpvYZfjtPCfKx2NUBJaGCAriuPVpKr4EtXlXtlGu2/5v4knDFdhj3EkfLyaqXR87dEtlh++mYEekS2QnZXWXouvTPMud67+l8vtk132yztF7BtCt2Wlma2bDUbxnTdz6kkA6zRAux4wFyUCL1HehvEHP8SSyVthnCLVM0aLA0+YuiDABPseOkDC8EVgRyKUbWT8Wre3h9htLgoA2E3weXAQsD/a3OX8ehZEgyv3klZyKwrH6q2toACVt5Jpz8CbxiDYew9AFbYVzSYo1ShqKDROPdYisE/hPqbzFR/2nZbYbTDGDU376mpRizrQLdhMHkMY=
+    on_failure: always
+    on_success: never
+
+cache:
+  directories:
+  - $HOME/.m2
+
+branches:
+    only:
+        - master

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>uk.gov.ons.tools</groupId>
   <artifactId>rabbit</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
 
   <name>rabbit</name>
   <url>https://github.com/ONSdigital/rabbit-tools</url>
@@ -16,6 +15,25 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
+
+  <scm>
+    <url>https://github.com/ONSdigital/rabbit-tools</url>
+    <connection>scm:git:https://github.com/ONSdigital/rabbit-tools</connection>
+    <developerConnection>scm:git:https://github.com/ONSdigital/rabbit-tools</developerConnection>
+  </scm>
+
+  <distributionManagement>
+    <repository>
+      <id>central</id>
+      <name>libs-release</name>
+      <url>http://artifactory-sdc.onsdigital.uk/artifactory/libs-release-local</url>
+    </repository>
+    <snapshotRepository>
+      <id>snapshots</id>
+      <name>libs-snapshots</name>
+      <url>http://artifactory-sdc.onsdigital.uk/artifactory/libs-snapshot-local</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <dependencies>
     <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
@@ -80,6 +98,14 @@
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+          <configuration>
+            <scmCommentPrefix>[ci skip]</scmCommentPrefix>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
# Background
We want to publish our release artifacts on a merge to master so they
can be used in other projects. These changes ensure travis will build
and push a release artifact only on merge from a PR to master.

# How to test
## Creating release and tag
1. Run `GITHUB_API_KEY=$github_api_key mvn -s .maven.settings.xml -B -Dusername=$GITHUB_API_KEY release:prepare;`
1. Run `ARTIFACTORY_PASSWORD=$artifactory_password mvn -s .maven.settings.xml -B release:perform;`

Note. this will push commits to this branch, tag the repo and create an artifact

## Tidying up release and tag
1. `git push --delete origin rabbit-1.0.0`
1. Log into artifactory with the same user
1. search for the rabbit-1.0.0 artifact by clicking the magnifying glass
1. login with travis user/password
1. Select the rabbit-1.0.0 artifacts excluding rabbitmq-jms-1.4.7.pom and rabbitmq-jms-1.4.7.jar
1. Press delete
1. Reset commits on this branch `git reset --hard 5d174c34b3be5bf4a2a673cb15288b82b817a4a4`
1. `git push origin publish-release-artifact -f`