### PR TITLE
Added method to allow messages to be posted direct to queue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.19.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/uk/gov/ons/tools/rabbit/SimpleMessageBase.java
+++ b/src/main/java/uk/gov/ons/tools/rabbit/SimpleMessageBase.java
@@ -27,15 +27,28 @@ public class SimpleMessageBase {
         this(rabbitmq.getHost(), rabbitmq.getPort(), rabbitmq.getUsername(), rabbitmq.getPassword());
     }
 
+    /**
+     * Constructor for use by unit tests
+     */
+    SimpleMessageBase(){}
+
     protected RabbitAdmin getRabbitAdmin(){
         return this.rabbitAdmin;
     }
 
-    protected ConnectionFactory getConnectionFactory(){
-        return this.connectionFactory;
-    }
-
     protected RabbitTemplate getRabbitTemplate(){
         return this.rabbitAdmin.getRabbitTemplate();
+    }
+
+    ConnectionFactory getConnectionFactory(){
+        return connectionFactory;
+    }
+
+    /**
+     * This setter is solely for use by unit tests
+     * @param rabbitAdmin a RabbitAdmin
+     */
+    void setRabbitAdmin(RabbitAdmin rabbitAdmin){
+        this.rabbitAdmin = rabbitAdmin;
     }
 }

--- a/src/main/java/uk/gov/ons/tools/rabbit/SimpleMessageSender.java
+++ b/src/main/java/uk/gov/ons/tools/rabbit/SimpleMessageSender.java
@@ -9,6 +9,13 @@ public class SimpleMessageSender extends SimpleMessageBase {
     }
 
     /**
+     * Constructor for use by unit tests
+     */
+    SimpleMessageSender(){
+        super();
+    }
+
+    /**
      * Constructor that accepts a Rabbitmq configuration object
      * @param rabbitmq a Rabbitmq configuration object populated by Spring or other means
      */

--- a/src/main/java/uk/gov/ons/tools/rabbit/SimpleMessageSender.java
+++ b/src/main/java/uk/gov/ons/tools/rabbit/SimpleMessageSender.java
@@ -27,4 +27,23 @@ public class SimpleMessageSender extends SimpleMessageBase {
 
         rabbitTemplate.convertAndSend(exchange, message);
     }
+
+    /**
+     * This method sends a message direct to a Rabbit queue.  It's use is really not recommended
+     * as all messages should go through an exchange.  However some of the RM services
+     * are accdientally posting direct to queues so this method is here to allow integration tests
+     * to mimic this behaviour.
+     *
+     * This works because, by default, queues are bound to the default exchange with the name of the
+     * queue as the routing key.
+     * Reference: https://goo.gl/mBqv13
+     *
+     * @param queueName the name of the queue to send the message to
+     * @param message the message to send
+     */
+    public void sendMessageToQueue(String queueName, String message){
+        RabbitTemplate rabbitTemplate = getRabbitTemplate();
+
+        rabbitTemplate.convertAndSend(queueName, message);
+    }
 }

--- a/src/test/java/uk/gov/ons/tools/rabbit/SimpleMessageSenderTest.java
+++ b/src/test/java/uk/gov/ons/tools/rabbit/SimpleMessageSenderTest.java
@@ -35,8 +35,6 @@ public class SimpleMessageSenderTest {
   public void testSendMessageToQueue(){
     String queueName  = "Queue.Name";
     String message = "\n"
-        + "Tags: generator, random, csv, csv generator\n"
-        + "Back JSON SQL HTML XML CSVCopy\n"
         + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
         + "<dataset>\n"
         + "\t<register>\n"
@@ -48,7 +46,7 @@ public class SimpleMessageSenderTest {
         + "\t\t<password>K,y899gY&+gV7Mp</password>\n"
         + "\t\t<cc>38732647699838</cc>\n"
         + "\t\t<lorem>In fermentum et sollicitudin ac orci phasellus egestas tellus rutrum. Et sollicitudin ac orci. Nibh mauris cursus mattis. Enim diam vulputate ut pharetra sit amet aliquam. Bibendum ut tristique et egestas. In massa tempor nec feugiat nisl pretium fusce id velit.</lorem>\n"
-        + "\t</register>";
+        + "\t</register></dataset>";
 
     this.sender.sendMessageToQueue(queueName, message);
 

--- a/src/test/java/uk/gov/ons/tools/rabbit/SimpleMessageSenderTest.java
+++ b/src/test/java/uk/gov/ons/tools/rabbit/SimpleMessageSenderTest.java
@@ -1,0 +1,63 @@
+package uk.gov.ons.tools.rabbit;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleMessageSenderTest {
+
+  @InjectMocks
+  private SimpleMessageSender sender;
+
+  @Mock
+  private RabbitAdmin rabbitAdmin;
+
+  @Mock
+  private RabbitTemplate rabbitTemplate;
+
+  @Before
+  public void setUp(){
+    when(this.rabbitAdmin.getRabbitTemplate()).thenReturn(this.rabbitTemplate);
+  }
+
+  @Test
+  public void testSendMessageToQueue(){
+    String queueName  = "Queue.Name";
+    String message = "\n"
+        + "Tags: generator, random, csv, csv generator\n"
+        + "Back JSON SQL HTML XML CSVCopy\n"
+        + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        + "<dataset>\n"
+        + "\t<register>\n"
+        + "\t\t<cpf>28409746816</cpf>\n"
+        + "\t\t<cnpj>17443311000128</cnpj>\n"
+        + "\t\t<ssn>591838486</ssn>\n"
+        + "\t\t<number>91</number>\n"
+        + "\t\t<name>Graig Woodcock</name>\n"
+        + "\t\t<password>K,y899gY&+gV7Mp</password>\n"
+        + "\t\t<cc>38732647699838</cc>\n"
+        + "\t\t<lorem>In fermentum et sollicitudin ac orci phasellus egestas tellus rutrum. Et sollicitudin ac orci. Nibh mauris cursus mattis. Enim diam vulputate ut pharetra sit amet aliquam. Bibendum ut tristique et egestas. In massa tempor nec feugiat nisl pretium fusce id velit.</lorem>\n"
+        + "\t</register>";
+
+    this.sender.sendMessageToQueue(queueName, message);
+
+    ArgumentCaptor<String> queueNameCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+
+    verify(this.rabbitTemplate).convertAndSend(queueNameCaptor.capture(), messageCaptor.capture());
+
+    assertEquals(queueName, queueNameCaptor.getValue());
+    assertEquals(message, messageCaptor.getValue());
+  }
+}


### PR DESCRIPTION
# Motivation and Context
Some of the RM services unintentionally post messages directly to a queue.  This PR adds a method to the supporting tools to allow integration tests to mimic this behaviour.  

# What has changed
- an additional method, sendMessageToQueue, has been added to the SimpleMessageSender class
- unit tests to test sendMessaegToQueue have been added

# How to test?
- check out branch
- run unit tests

# Links
- [Method pinched from StackOverflow](https://goo.gl/mBqv13)