### PR TITLE
Increase queue capacity

### DIFF
--- a/src/main/java/uk/gov/ons/tools/rabbit/SimpleMessageListener.java
+++ b/src/main/java/uk/gov/ons/tools/rabbit/SimpleMessageListener.java
@@ -70,7 +70,7 @@ public class SimpleMessageListener extends SimpleMessageBase {
 
         declareExchangeAndBind(rabbitAdmin, queue, type, exchangeName, routingKey);
 
-        final BlockingQueue<String> transfer = new ArrayBlockingQueue<>(5);
+        final BlockingQueue<String> transfer = new ArrayBlockingQueue<>(100);
 
         MessageListener messageListener = new MessageListener(){
             @Override


### PR DESCRIPTION
# Motivation and Context
If using queue exceeds 5 messages there are lots of capacity errors.
Increasing to 100 as 5 seems too low.

# What has changed
Increase queue capacity to 100

# How to test?
1. Create file TestBlockingQueueCapacity.java with contents
	```
	package uk.gov.ons.ctp.common;
	
	import java.util.concurrent.BlockingQueue;
	import java.util.concurrent.LinkedBlockingQueue;
	
	public class TestBlockingQueueCapacity {
	
	  public static void main(String[] args) {
	      BlockingQueue<String> queue = new LinkedBlockingQueue<>(1);
	      queue.add("test");
	      queue.add("test");
	  }
	}
	```
2. Run main method and observe error
	```
	Exception in thread "main" java.lang.IllegalStateException: Queue full
	at java.util.AbstractQueue.add(AbstractQueue.java:98)
	at uk.gov.ons.ctp.common.TestBlockingQueueCapacity.main(TestBlockingQueueCapacity.java:11)
	```
